### PR TITLE
python: ttfautohint: Python 3.12 support

### DIFF
--- a/src/python/ttfautohint/_version.py
+++ b/src/python/ttfautohint/_version.py
@@ -1,11 +1,3 @@
-try:
-    from pkg_resources import get_distribution, DistributionNotFound
-    __version__ = get_distribution("ttfautohint-py").version
-except (ImportError, DistributionNotFound):
-    # either pkg_resources is missing or package is not installed
-    import warnings
-    warnings.warn(
-        "'ttfautohint-py' is missing the required distribution metadata. "
-        "Please make sure it was installed correctly.", UserWarning,
-        stacklevel=2)
-    __version__ = "0.0.0"
+from importlib import metadata
+
+__version__ = metadata.version("ttfautohint-py")


### PR DESCRIPTION
Since python 3.12, pkg_resources has been moved to setuptools. Also, it is deprecated.

- https://github.com/Kozea/Radicale/issues/1184
- https://github.com/mu-editor/mu/issues/2485
- https://github.com/python/cpython/issues/95299

```sh
$ python -m ttfautohint --help
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/ttfautohint/_version.py", line 2, in <module>
    from pkg_resources import get_distribution, DistributionNotFound
ModuleNotFoundError: No module named 'pkg_resources'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 148, in _get_module_details
  File "<frozen runpy>", line 112, in _get_module_details
  File "/usr/lib/python3.12/site-packages/ttfautohint/__init__.py", line 12, in <module>
    from ttfautohint._version import __version__
  File "/usr/lib/python3.12/site-packages/ttfautohint/_version.py", line 4, in <module>
    except (ImportError, DistributionNotFound):
                         ^^^^^^^^^^^^^^^^^^^^
NameError: name 'DistributionNotFound' is not defined
```