### PR TITLE
Fix PyPI deployment failing on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,13 @@ jobs:
             git
             mingw-w64-i686-ragel
             mingw-w64-x86_64-ragel
-      - name: "Configure Git for Windows to disable line endings normalization"
+      - name: "Configure MSYS2 Git to match Github's git autocrlf settings (Windows)"
         if: startsWith(matrix.os, 'windows')
+        shell: pwsh
         run: |
-          git config --global core.autocrlf false
-          msys2 -c "git config --global core.autocrlf false"
+          $autocrlf = git config --get core.autocrlf
+          Write-Output "GitHub Git core.autocrlf: $autocrlf"
+          msys2 -c "git config --global core.autocrlf $autocrlf"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,16 @@ jobs:
             git
             mingw-w64-i686-ragel
             mingw-w64-x86_64-ragel
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Set up environment
+        shell: bash
+        # applying patches makes the working directory 'dirty', which changes the
+        # git-generated version, so we save the current version beforehand
+        run: |
+          python -m pip install setuptools_scm
+          echo CIBW_ENVIRONMENT="$CIBW_ENVIRONMENT SETUPTOOLS_SCM_PRETEND_VERSION=$(python setup.py --version)" >> $GITHUB_ENV
       - name: "Install MinGW-w64 with win32 threads (Windows)"
         if: startsWith(matrix.os, 'windows')
         shell: bash
@@ -102,16 +112,6 @@ jobs:
           # Download MinGW-w64 with win32 threads (32-bit)
           curl -L -o mingw32.7z "https://github.com/niXman/mingw-builds-binaries/releases/download/15.1.0-rt_v12-rev0/i686-15.1.0-release-win32-dwarf-msvcrt-rt_v12-rev0.7z"
           7z x mingw32.7z -o/c/mingw-win32/
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-      - name: Set up environment
-        shell: bash
-        # applying patches makes the working directory 'dirty', which changes the
-        # git-generated version, so we save the current version beforehand
-        run: |
-          python -m pip install setuptools_scm
-          echo CIBW_ENVIRONMENT="$CIBW_ENVIRONMENT SETUPTOOLS_SCM_PRETEND_VERSION=$(python setup.py --version)" >> $GITHUB_ENV
       - name: Apply local patches
         shell: bash
         run: src/c/apply_patches.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,11 @@ jobs:
             git
             mingw-w64-i686-ragel
             mingw-w64-x86_64-ragel
-      - name: "Configure MSYS2 Git to match Github's git autocrlf settings (Windows)"
+      - name: "Configure Git for Windows to disable line endings normalization"
         if: startsWith(matrix.os, 'windows')
-        shell: pwsh
         run: |
-          $autocrlf = git config --get core.autocrlf
-          Write-Output "GitHub Git core.autocrlf: $autocrlf"
-          msys2 -c "git config --global core.autocrlf $autocrlf"
+          git config --global core.autocrlf false
+          msys2 -c "git config --global core.autocrlf false"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,9 @@ jobs:
             mingw-w64-x86_64-ragel
       - name: "Configure Git for Windows to disable line endings normalization"
         if: startsWith(matrix.os, 'windows')
-        run: git config --global core.autocrlf false
+        run: |
+          git config --global core.autocrlf false
+          msys2 -c "git config --global core.autocrlf false"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,7 @@ jobs:
             mingw-w64-x86_64-ragel
       - name: "Configure Git for Windows to disable line endings normalization"
         if: startsWith(matrix.os, 'windows')
-        run: |
-          git config --global core.autocrlf false
-          msys2 -c "git config --global core.autocrlf false"
+        run: git config --global core.autocrlf false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,9 +112,6 @@ jobs:
           # Download MinGW-w64 with win32 threads (32-bit)
           curl -L -o mingw32.7z "https://github.com/niXman/mingw-builds-binaries/releases/download/15.1.0-rt_v12-rev0/i686-15.1.0-release-win32-dwarf-msvcrt-rt_v12-rev0.7z"
           7z x mingw32.7z -o/c/mingw-win32/
-      - name: Apply local patches
-        shell: bash
-        run: src/c/apply_patches.sh
       - name: Update path (Mac)
         if: startsWith(matrix.os, 'macos')
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
             git
             mingw-w64-i686-ragel
             mingw-w64-x86_64-ragel
+      - name: "Configure Git for Windows to disable line endings normalization"
+        if: startsWith(matrix.os, 'windows')
+        run: git config --global core.autocrlf false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,9 +91,6 @@ jobs:
             git
             mingw-w64-i686-ragel
             mingw-w64-x86_64-ragel
-      - name: "Configure Git for Windows to disable line endings normalization"
-        if: startsWith(matrix.os, 'windows')
-        run: git config --global core.autocrlf false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,10 @@ jobs:
       # on Windows I need '/d' flag to change both drive and directory at once
       CIBW_TEST_COMMAND_WINDOWS: cd /d {project} && coverage run --parallel-mode -m pytest
     steps:
+      # https://github.com/msys2/setup-msys2?tab=readme-ov-file#actionscheckout-and-line-endings
+      - name: "Configure Git for Windows to leave line endings alone"
+        if: startsWith(matrix.os, 'windows')
+        run: git config --global core.autocrlf input
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,5 @@
 	url = https://github.com/harfbuzz/harfbuzz
 [submodule "src/c/ttfautohint"]
 	path = src/c/ttfautohint
-	url = http://repo.or.cz/ttfautohint.git
+	url = https://github.com/fonttools/ttfautohint
+	branch = gnulib-gh-mirror

--- a/setup.py
+++ b/setup.py
@@ -112,9 +112,9 @@ class CustomClean(clean):
     def run(self):
         clean.run(self)
         if not self.dry_run:
-            # if -a, also git clean submodules to remove all the build byproducts
+            # if -a, also reset submodules to remove all the build byproducts
             if self.all:
-                subprocess.call(
+                subprocess.run(
                     [
                         "git",
                         "submodule",
@@ -123,9 +123,31 @@ class CustomClean(clean):
                         "git",
                         "clean",
                         "-fdx",
+                    ],
+                    check=True,
+                )
+                subprocess.run(
+                    [
+                        "git",
+                        "submodule",
+                        "foreach",
+                        "--recursive",
+                        "git",
+                        "reset",
+                        "--hard",
                     ]
                 )
-            subprocess.call(["make", "clean"], cwd=os.path.join("src", "c"))
+                subprocess.run(
+                    [
+                        "git",
+                        "submodule",
+                        "update",
+                        "--init",
+                        "--recursive",
+                    ],
+                    check=True,
+                )
+            subprocess.run(["make", "clean"], cwd=os.path.join("src", "c"), check=True)
 
 
 ttfautohint_exe = Executable(

--- a/src/c/Makefile
+++ b/src/c/Makefile
@@ -24,8 +24,8 @@ ifneq (,$(findstring MINGW,$(shell uname -s)))
 	LDFLAGS += -static -static-libgcc -static-libstdc++
 endif
 
-$(info DEBUG: uname -s returns: $(shell uname -s))
-$(info DEBUG: Final LDFLAGS: $(LDFLAGS))
+# $(info DEBUG: uname -s returns: $(shell uname -s))
+# $(info DEBUG: Final LDFLAGS: $(LDFLAGS))
 
 all: ttfautohint
 


### PR DESCRIPTION
somehow the git repo's working directory is dirty and the scm version generated is invalid for upload to PyPI, but only happened for the windows wheel:
https://github.com/fonttools/ttfautohint-py/actions/runs/16660292388/job/47157914348

this PR tries to fix that